### PR TITLE
Add minimal LLM settings and resolver

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -57,3 +57,10 @@ USE_MCP= # true
 
 # AI analysis on failures
 AUTO_ANALYZE_ERRORS=true
+
+# LLM settings (overrides stored settings)
+LLM_ENABLED=false # set to true to enable LLM features
+LLM_PROVIDER=none # none | openai | ollama | lmstudio | litellm
+LLM_DEFAULT_MODEL=
+OLLAMA_URL=http://localhost:11434
+LM_STUDIO_URL=http://localhost:1234/v1

--- a/src/common/llmConfig.ts
+++ b/src/common/llmConfig.ts
@@ -1,22 +1,30 @@
-export type LlmProvider = 'ollama' | 'open-interpreter';
+import { getSettings } from '../settings/store';
 
-export const llmConfig = {
-  provider: (process.env.LLM_PROVIDER as LlmProvider) || 'ollama',
-  model: process.env.LLM_MODEL || 'gpt-oss:20b',
+export type LlmConfig = ReturnType<typeof getSettings>['llm'];
 
-  // Ollama: single var handles protocol+host:port
-  ollamaHost: process.env.OLLAMA_HOST || 'http://127.0.0.1:11434',
+export function getLlmConfig(): LlmConfig {
+  const s = getSettings().llm;
+  return {
+    ...s,
+    enabled: process.env.LLM_ENABLED
+      ? process.env.LLM_ENABLED === 'true'
+      : s.enabled,
+    provider:
+      (process.env.LLM_PROVIDER as LlmConfig['provider'] | undefined) ??
+      s.provider,
+    defaultModel: process.env.LLM_DEFAULT_MODEL ?? s.defaultModel,
+    baseURL: process.env.OPENAI_BASE_URL ?? s.baseURL,
+    apiKey: process.env.OPENAI_API_KEY ?? s.apiKey,
+    ollamaURL: process.env.OLLAMA_URL ?? s.ollamaURL,
+    lmstudioURL: process.env.LM_STUDIO_URL ?? s.lmstudioURL,
+  };
+}
 
-  // Open Interpreter server host/port (http://host:port)
-  interpHost: process.env.INTERPRETER_SERVER_HOST || '127.0.0.1',
-  interpPort: Number(process.env.INTERPRETER_SERVER_PORT || 8000),
-  interpOffline: process.env.INTERPRETER_OFFLINE
-    ? process.env.INTERPRETER_OFFLINE === 'true'
-    : false,
-  interpVerbose: process.env.INTERPRETER_VERBOSE
-    ? process.env.INTERPRETER_VERBOSE === 'true'
-    : true,
-
-  // In CI/tests we keep the simple shim behavior so tests remain deterministic
-  useShim: process.env.NODE_ENV === 'test' && !process.env.LLM_PROVIDER,
-};
+export const llmConfig = (() => {
+  const cfg = getLlmConfig();
+  return {
+    ...cfg,
+    model: cfg.defaultModel,
+    ollamaHost: cfg.ollamaURL,
+  } as any;
+})();

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -44,6 +44,19 @@ export const SettingsSchema = z.object({
     executeCode: ExecuteCodeSchema.default({}),
     executeLlm: ExecuteLlmSchema.default({}),
   }).default({}),
+  llm: z
+    .object({
+      enabled: z.boolean().default(false),
+      provider: z
+        .enum(['none', 'openai', 'ollama', 'lmstudio', 'litellm'])
+        .default('none'),
+      defaultModel: z.string().default(''),
+      baseURL: z.string().default(''),
+      apiKey: z.string().default(''),
+      ollamaURL: z.string().default('http://localhost:11434'),
+      lmstudioURL: z.string().default('http://localhost:1234/v1'),
+    })
+    .default({}),
 });
 
 export type Settings = z.infer<typeof SettingsSchema>;

--- a/src/settings/store.ts
+++ b/src/settings/store.ts
@@ -77,6 +77,7 @@ export const SettingsStore = {
           }
         : _settings.features,
       app: partial.app ? { ..._settings.app, ...partial.app } : _settings.app,
+      llm: partial.llm ? { ..._settings.llm, ...partial.llm } : _settings.llm,
     });
     _settings = merged;
     scheduleSave();
@@ -105,3 +106,7 @@ export const SettingsStore = {
     });
   },
 };
+
+export function getSettings(): Settings {
+  return SettingsStore.get();
+}


### PR DESCRIPTION
## Summary
- add `llm` block to settings schema
- persist llm settings and expose helper
- implement resolver with env overrides and document env vars

## Testing
- `npm run check-types`
- `npm run build`
- `npm test`
- `npx ts-node -e "const { getLlmConfig } = require('./src/common/llmConfig'); console.log(getLlmConfig());"`
- `npm start` (terminated after launch)


------
https://chatgpt.com/codex/tasks/task_e_68a2600be6ac832cb7944c5d852d764e