### PR TITLE
docs: document optional LLM config and deprecate executeFile

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -41,13 +41,16 @@ HTTPS_ENABLED= # false
 HTTPS_KEY_PATH= # path/to/your/private.key
 HTTPS_CERT_PATH= # path/to/your/certificate.crt
 
-# Model selection and AI providers
-DEFAULT_MODEL=gpt-oss:20b
-AI_PROVIDER=ollama  # or lmstudio, openai
-OLLAMA_BASE_URL=http://localhost:11434
-LMSTUDIO_BASE_URL=http://localhost:1234
-OPENAI_BASE_URL=https://api.openai.com
-OPENAI_API_KEY=
+# LLM configuration (optional)
+LLM_ENABLED=false # set to true to enable LLM features
+LLM_PROVIDER=none # options: ollama, lmstudio, openai
+DEFAULT_MODEL=gpt-oss:20b # logical model when LLM is enabled
+
+# Provider-specific settings
+OLLAMA_BASE_URL=http://localhost:11434 # used when LLM_PROVIDER=ollama
+LMSTUDIO_BASE_URL=http://localhost:1234 # used when LLM_PROVIDER=lmstudio
+OPENAI_BASE_URL=https://api.openai.com # OpenAI or LiteLLM proxy
+OPENAI_API_KEY= # required when LLM_PROVIDER=openai
 
 # Streaming
 SSE_HEARTBEAT_MS=15000
@@ -56,4 +59,4 @@ SSE_HEARTBEAT_MS=15000
 USE_MCP= # true
 
 # AI analysis on failures
-AUTO_ANALYZE_ERRORS=true
+AUTO_ANALYZE_ERRORS=true # silently ignored when LLM_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Competition entry: AI-assisted CLI with gpt-oss:20b for automatic error diagnosis and natural-language execution.
 
+**Works without AI**: Core features run with zero LLM configuration; AI helpers are optional and disabled by default.
+
 ## Quickstart
 
 ### Run Directly from Docker Hub
@@ -31,6 +33,19 @@ Competition entry: AI-assisted CLI with gpt-oss:20b for automatic error diagnosi
 For more detailed instructions and alternative installation methods, please refer to the sections below.
 
 
+## Enable LLM (optional)
+
+LLM features are off by default. Enable them with one-line environment overrides:
+
+- **LiteLLM proxy (OpenAI-compatible)**
+  ```sh
+  LLM_ENABLED=true LLM_PROVIDER=openai OPENAI_BASE_URL=http://localhost:4000 OPENAI_API_KEY=sk-xxx npm start
+  ```
+- **Ollama**
+  ```sh
+  LLM_ENABLED=true LLM_PROVIDER=ollama OLLAMA_BASE_URL=http://localhost:11434 npm start
+  ```
+
 ## Introduction
 
 GPT Terminal Plus provides a secure and isolated environment where system CLI utilities can be accessed via HTTP endpoints. Beyond simple command execution, it performs automatic AI analysis of failures and returns actionable fixes back to the calling AI.
@@ -45,11 +60,12 @@ The primary purpose of GPT Terminal Plus is to grant access to system CLI utilit
 ## Primary Features (Two Ways We Use gpt-oss:20b)
 
 - AI Error Analysis and Autodiagnostics: when a shell, code, or file execution exits non‑zero, the system invokes `gpt-oss:20b` (if available) to analyze `stderr`, `stdout`, and `exitCode`, returning concise remediation steps and suggested fixes in the response. This provides immediate, high‑value feedback to the calling AI.
+  - When `LLM_ENABLED=false`, this analysis silently disables itself.
 
 See docs/API.md → AI Error Analysis.
 
 ## Secondary Features
-- Command Execution: Run system commands using Bash; execute code (Python, TypeScript); run files.
+- Command Execution: Run system commands using Bash; execute code (Python, TypeScript); run files. `executeFile` is deprecated—use `/command/execute` with a shell command instead.
 - Model Selection: Choose logical models via `/model` routes; providers: Ollama, LM Studio, OpenAI.
 - Streaming Chat: `POST /chat/completions` with SSE streaming, heartbeats, and error events.
 - File Management: Create, read, update, and delete files securely.

--- a/docs/API.md
+++ b/docs/API.md
@@ -91,7 +91,7 @@ When an execution returns a non‑zero exit code, endpoints attach an `aiAnalysi
 - Affected endpoints:
   - `POST /command/execute`
   - `POST /command/execute-code`
-  - `POST /command/execute-file`
+  - ~~`POST /command/execute-file`~~ (deprecated; use `/command/execute` with a shell command)
 
 - Response shape (example):
   ```json

--- a/docs/CONFIG.envvars.md
+++ b/docs/CONFIG.envvars.md
@@ -62,6 +62,19 @@ BACKUP_EXTENSION=.bak
 - **`BACKUP_EXTENSION`**
   - **Description**: Specifies the extension used for backup files.
   - **Default**: `.bak`
+ 
+## LLM Configuration (optional)
+
+```ini
+LLM_ENABLED=false
+LLM_PROVIDER=none  # ollama, lmstudio, openai
+DEFAULT_MODEL=gpt-oss:20b
+OLLAMA_BASE_URL=http://localhost:11434  # LLM_PROVIDER=ollama
+LMSTUDIO_BASE_URL=http://localhost:1234  # LLM_PROVIDER=lmstudio
+OPENAI_BASE_URL=https://api.openai.com  # OpenAI or LiteLLM proxy
+OPENAI_API_KEY= # required when LLM_PROVIDER=openai
+AUTO_ANALYZE_ERRORS=true # ignored when LLM_ENABLED=false
+```
 
 ## Third-Party Service Configuration
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -192,19 +192,19 @@ HTTPS_CERT_PATH=path/to/your/certificate.crt
 
 ## AI Providers and Models
 
-The chat API uses a provider adapter with sensible defaults. You can configure the provider and model mapping via your config files under the `ai` key, and control the default logical model with `DEFAULT_MODEL`.
+The chat API uses a provider adapter with sensible defaults. LLM features are optional and disabled unless `LLM_ENABLED=true`. You can configure the provider and model mapping via your config files under the `ai` key and control the default logical model with `DEFAULT_MODEL`.
 
 ### Environment Variables
 
 ```ini
-# Optional: default logical model to use if none selected
+LLM_ENABLED=false
+LLM_PROVIDER=none   # ollama, lmstudio, openai
 DEFAULT_MODEL=gpt-oss:20b
-AI_PROVIDER=ollama   # or lmstudio, openai
-OLLAMA_BASE_URL=http://localhost:11434
-LMSTUDIO_BASE_URL=http://localhost:1234
-OPENAI_BASE_URL=https://api.openai.com
-OPENAI_API_KEY=sk-...
-AUTO_ANALYZE_ERRORS=true
+OLLAMA_BASE_URL=http://localhost:11434   # required when LLM_PROVIDER=ollama
+LMSTUDIO_BASE_URL=http://localhost:1234   # required when LLM_PROVIDER=lmstudio
+OPENAI_BASE_URL=https://api.openai.com   # OpenAI or LiteLLM proxy
+OPENAI_API_KEY=sk-...                    # required when LLM_PROVIDER=openai
+AUTO_ANALYZE_ERRORS=true                 # ignored when LLM_ENABLED=false
 ```
 
 ### Config Structure (config/production.json or config/test/test.json)

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -200,6 +200,8 @@
       "post": {
         "operationId": "executeFile",
         "summary": "Execute a file present on the server/target",
+        "deprecated": true,
+        "description": "Deprecated. Use `/command/execute` with a shell command instead.\n",
         "security": [
           {
             "bearerAuth": []

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -123,6 +123,9 @@ paths:
     post:
       operationId: executeFile
       summary: Execute a file present on the server/target
+      deprecated: true
+      description: |
+        Deprecated. Use `/command/execute` with a shell command instead.
       security:
         - bearerAuth: []
       requestBody:

--- a/src/openapi.docs.ts
+++ b/src/openapi.docs.ts
@@ -130,6 +130,9 @@
  *   post:
  *     operationId: executeFile
  *     summary: Execute a file present on the server/target
+ *     deprecated: true
+ *     description: |
+ *       Deprecated. Use `/command/execute` with a shell command instead.
  *     security:
  *       - bearerAuth: []
  *     requestBody:


### PR DESCRIPTION
## Summary
- document optional LLM environment variables and set LLM off by default
- add README instructions for enabling LLM providers and note executeFile deprecation
- mark execute-file route deprecated in OpenAPI and docs

## Testing
- `npm run openapi:generate`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2608a34fc832caccc0a40739a01b9