### PR TITLE
feat(mcp): OAuth 2.0 protected-resource gateway for /mcp

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -69,6 +69,19 @@ INTERPRETER_SERVER_PORT=
 INTERPRETER_OFFLINE=            # false
 INTERPRETER_VERBOSE=            # true
 
+# ─── MCP OAuth gateway (optional) ────────────────────────────────────────────
+# When enabled, the /mcp endpoint becomes an OAuth 2.0 protected resource
+# (RFC 9728): it advertises its authorization server at
+# /.well-known/oauth-protected-resource and validates incoming bearer JWTs
+# against the AS's JWKS. The static API token still works unless fallback is off.
+MCP_OAUTH_ENABLED=                    # true to enable OAuth on /mcp (default off)
+MCP_OAUTH_ISSUER=                     # e.g. https://your-tenant.auth0.com/
+MCP_OAUTH_JWKS_URI=                   # e.g. https://your-tenant.auth0.com/.well-known/jwks.json
+MCP_OAUTH_AUDIENCE=                   # token audience (defaults to MCP_OAUTH_RESOURCE)
+MCP_OAUTH_RESOURCE=                   # canonical resource URI, e.g. https://host/mcp
+MCP_OAUTH_SCOPES=                     # optional, comma/space-separated
+MCP_OAUTH_ALLOW_STATIC_FALLBACK=      # false to require a JWT (default: static token still accepted)
+
 # ─── Misc ────────────────────────────────────────────────────────────────────
 GTP_SETTINGS_PATH=              # path to persisted settings JSON
 NGROK_ENABLED=                  # true to open an ngrok tunnel at startup

--- a/docs/MCP_OAUTH.md
+++ b/docs/MCP_OAUTH.md
@@ -1,0 +1,77 @@
+# MCP OAuth Gateway
+
+The `/mcp` endpoint (Streamable HTTP) can run as an **OAuth 2.0 protected
+resource** following the MCP authorization model (MCP spec 2025-06-18, which
+builds on OAuth 2.1 + [RFC 9728 Protected Resource Metadata](https://www.rfc-editor.org/rfc/rfc9728)).
+
+This is **off by default**. With it off, `/mcp` is protected by the same static
+bearer API token as the REST API — no behavior change.
+
+## What it does when enabled
+
+1. **Advertises an authorization server.** A public discovery document is served
+   at:
+
+   ```
+   GET /.well-known/oauth-protected-resource
+   ```
+
+   ```json
+   {
+     "resource": "https://your-host/mcp",
+     "authorization_servers": ["https://your-tenant.auth0.com/"],
+     "jwks_uri": "https://your-tenant.auth0.com/.well-known/jwks.json",
+     "bearer_methods_supported": ["header"],
+     "scopes_supported": ["mcp:invoke"]
+   }
+   ```
+
+2. **Validates bearer JWTs.** Incoming `Authorization: Bearer <jwt>` tokens are
+   verified against the authorization server's JWKS (signature, `iss`, `aud`,
+   `exp`). Audience binding (RFC 8707) prevents token passthrough.
+
+3. **Challenges unauthenticated clients** with a `WWW-Authenticate` header that
+   points back at the metadata document, so spec-compliant MCP clients can
+   discover the AS and complete the flow:
+
+   ```
+   WWW-Authenticate: Bearer resource_metadata="https://your-host/.well-known/oauth-protected-resource"
+   ```
+
+4. **Keeps a static-token fallback** (on by default) so local/CLI usage with the
+   API token keeps working. Set `MCP_OAUTH_ALLOW_STATIC_FALLBACK=false` to
+   require a JWT.
+
+## Configuration
+
+| Env var | Required | Description |
+| --- | --- | --- |
+| `MCP_OAUTH_ENABLED` | — | `true` to enable (default off) |
+| `MCP_OAUTH_ISSUER` | yes | Authorization server issuer URL |
+| `MCP_OAUTH_JWKS_URI` | yes | AS JWKS endpoint used to verify token signatures |
+| `MCP_OAUTH_AUDIENCE` | yes* | Expected token audience (*defaults to `MCP_OAUTH_RESOURCE`) |
+| `MCP_OAUTH_RESOURCE` | yes* | Canonical resource URI for this server (*defaults to `MCP_OAUTH_AUDIENCE`) |
+| `MCP_OAUTH_SCOPES` | no | Advertised scopes (comma/space-separated) |
+| `MCP_OAUTH_ALLOW_STATIC_FALLBACK` | no | `false` to reject the static API token (default: accept it) |
+
+### Example (Auth0)
+
+```bash
+MCP_OAUTH_ENABLED=true
+MCP_OAUTH_ISSUER=https://your-tenant.auth0.com/
+MCP_OAUTH_JWKS_URI=https://your-tenant.auth0.com/.well-known/jwks.json
+MCP_OAUTH_AUDIENCE=https://your-host/mcp
+MCP_OAUTH_RESOURCE=https://your-host/mcp
+MCP_OAUTH_SCOPES=mcp:invoke
+```
+
+Any standards-compliant OAuth 2.0 / OIDC provider that publishes a JWKS works
+(Auth0, Keycloak, Microsoft Entra, Okta, etc.).
+
+## Scope & limitations
+
+This implements the **resource-server** half of the MCP auth model — the half
+MCP clients actually negotiate against. The token-issuing **authorization
+server** is expected to be an external IdP. An embedded authorization server
+(local `/authorize` + `/token` + dynamic client registration) is **not** included
+and is tracked as a future roadmap item.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "express": "^4.21.0",
         "express-rate-limit": "^8.1.0",
         "helmet": "^7.1.0",
+        "jose": "^5.10.0",
         "lru-cache": "^11.0.0",
         "module-alias": "^2.2.3",
         "morgan": "^1.10.0",
@@ -4485,6 +4486,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
@@ -14330,9 +14340,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "express": "^4.21.0",
     "express-rate-limit": "^8.1.0",
     "helmet": "^7.1.0",
+    "jose": "^5.10.0",
     "lru-cache": "^11.0.0",
     "module-alias": "^2.2.3",
     "morgan": "^1.10.0",

--- a/src/auth/mcpOAuth.ts
+++ b/src/auth/mcpOAuth.ts
@@ -1,0 +1,137 @@
+/**
+ * OAuth 2.0 protected-resource support for the MCP endpoint.
+ *
+ * Implements the MCP authorization model (MCP spec 2025-06-18, which adopts
+ * OAuth 2.1 + RFC 9728 Protected Resource Metadata): the MCP server is an OAuth
+ * *resource server*. It advertises which authorization server(s) issue tokens
+ * for it via /.well-known/oauth-protected-resource, and validates incoming
+ * bearer tokens as audience-bound JWTs against the AS's JWKS.
+ *
+ * This is OFF by default (MCP_OAUTH_ENABLED!=='true'); when disabled the MCP
+ * endpoint keeps using the static API token exactly as before. When enabled, a
+ * valid JWT is accepted and — unless MCP_OAUTH_ALLOW_STATIC_FALLBACK==='false'
+ * — the static API token still works too (handy for local/CLI use).
+ */
+import type { Request, Response, NextFunction } from 'express';
+import { createRemoteJWKSet, jwtVerify, type JWTPayload } from 'jose';
+import { convictConfig } from '../config/convictConfig';
+import { getOrGenerateApiToken } from '../common/apiToken';
+
+export interface McpOAuthConfig {
+  enabled: boolean;
+  issuer: string;
+  jwksUri: string;
+  audience: string;
+  /** Canonical resource identifier for this MCP server (RFC 8707). */
+  resource: string;
+  scopes: string[];
+  allowStaticFallback: boolean;
+}
+
+export function getMcpOAuthConfig(): McpOAuthConfig {
+  const env = process.env;
+  return {
+    enabled: env.MCP_OAUTH_ENABLED === 'true',
+    issuer: env.MCP_OAUTH_ISSUER || '',
+    jwksUri: env.MCP_OAUTH_JWKS_URI || '',
+    audience: env.MCP_OAUTH_AUDIENCE || env.MCP_OAUTH_RESOURCE || '',
+    resource: env.MCP_OAUTH_RESOURCE || env.MCP_OAUTH_AUDIENCE || '',
+    scopes: (env.MCP_OAUTH_SCOPES || '')
+      .split(/[,\s]+/)
+      .map((s) => s.trim())
+      .filter(Boolean),
+    allowStaticFallback: env.MCP_OAUTH_ALLOW_STATIC_FALLBACK !== 'false',
+  };
+}
+
+/**
+ * RFC 9728 Protected Resource Metadata document. Returned from
+ * GET /.well-known/oauth-protected-resource so MCP clients can discover which
+ * authorization server to obtain a token from.
+ */
+export function protectedResourceMetadata(cfg: McpOAuthConfig, fallbackResource: string) {
+  const doc: Record<string, unknown> = {
+    resource: cfg.resource || fallbackResource,
+    authorization_servers: cfg.issuer ? [cfg.issuer] : [],
+    bearer_methods_supported: ['header'],
+  };
+  if (cfg.scopes.length) doc.scopes_supported = cfg.scopes;
+  if (cfg.jwksUri) doc.jwks_uri = cfg.jwksUri;
+  return doc;
+}
+
+// Lazily-built, cached JWKS resolver keyed by URI (jose caches the keys itself).
+let jwksUriCached: string | null = null;
+let jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
+function getJwks(uri: string) {
+  if (!jwks || jwksUriCached !== uri) {
+    jwks = createRemoteJWKSet(new URL(uri));
+    jwksUriCached = uri;
+  }
+  return jwks;
+}
+
+/** Test-only: drop the cached JWKS resolver between tests. */
+export function __resetJwksForTests(): void {
+  jwks = null;
+  jwksUriCached = null;
+}
+
+export async function verifyBearerJwt(token: string, cfg: McpOAuthConfig): Promise<JWTPayload> {
+  if (!cfg.jwksUri) throw new Error('MCP OAuth misconfigured: MCP_OAUTH_JWKS_URI is required');
+  const { payload } = await jwtVerify(token, getJwks(cfg.jwksUri), {
+    issuer: cfg.issuer || undefined,
+    audience: cfg.audience || undefined,
+  });
+  return payload;
+}
+
+function staticApiToken(): string {
+  const overridden = convictConfig().get('security.apiToken') as string | undefined;
+  return overridden || getOrGenerateApiToken();
+}
+
+function bearer(req: Request): string | undefined {
+  const h = req.headers['authorization'];
+  if (!h) return undefined;
+  const [scheme, value] = h.split(' ');
+  return scheme && /^bearer$/i.test(scheme) ? value : undefined;
+}
+
+/**
+ * Auth middleware for the MCP endpoint. Delegates to the static-token check
+ * when OAuth is disabled; otherwise validates the bearer JWT (with optional
+ * static-token fallback). On failure emits a WWW-Authenticate challenge that
+ * points clients at the protected-resource metadata, per the MCP spec.
+ */
+export function mcpAuth(staticCheck: (req: Request, res: Response, next: NextFunction) => void) {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const cfg = getMcpOAuthConfig();
+    if (!cfg.enabled) return staticCheck(req, res, next);
+
+    const token = bearer(req);
+    const metadataUrl = `${req.protocol}://${req.get('host')}/.well-known/oauth-protected-resource`;
+    const challenge = (desc?: string) =>
+      `Bearer resource_metadata="${metadataUrl}"` + (desc ? `, error="invalid_token", error_description="${desc}"` : '');
+
+    if (!token) {
+      res.setHeader('WWW-Authenticate', challenge());
+      res.status(401).json({ error: 'Unauthorized', message: 'Bearer token required' });
+      return;
+    }
+
+    // Static API token fallback (kept for local/CLI use unless disabled).
+    if (cfg.allowStaticFallback && token === staticApiToken()) {
+      return next();
+    }
+
+    try {
+      const payload = await verifyBearerJwt(token, cfg);
+      (req as any).auth = payload;
+      next();
+    } catch (e: any) {
+      res.setHeader('WWW-Authenticate', challenge(e?.message || 'token verification failed'));
+      res.status(401).json({ error: 'Unauthorized', message: 'Invalid token' });
+    }
+  };
+}

--- a/src/modules/mcpServer.ts
+++ b/src/modules/mcpServer.ts
@@ -5,6 +5,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { registerMcpTools } from "./mcpTools";
 import { checkAuthToken } from "../middlewares/checkAuthToken";
+import { mcpAuth, getMcpOAuthConfig, protectedResourceMetadata } from "../auth/mcpOAuth";
 
 // NOTE: the deprecated SSE transport (GET /mcp/messages) was removed in favor
 // of the MCP Streamable HTTP transport (spec 2025-03-26+), which modern
@@ -17,13 +18,33 @@ import { checkAuthToken } from "../middlewares/checkAuthToken";
  *   GET    /mcp  — server-to-client notification stream (SSE within Streamable HTTP)
  *   DELETE /mcp  — session termination
  *
- * All methods require the standard bearer token (same as the REST API).
+ * Auth: by default every method requires the standard bearer token (same as the
+ * REST API). When MCP_OAUTH_ENABLED=true the endpoint additionally accepts
+ * OAuth 2.0 JWTs (validated against the configured authorization server) and
+ * advertises itself as an RFC 9728 protected resource at
+ * /.well-known/oauth-protected-resource.
  */
 export function setupMcpServer(app: express.Application, basePath = "/mcp"): void {
   // session id -> active transport
   const transports: Record<string, StreamableHTTPServerTransport> = {};
 
-  app.post(basePath, checkAuthToken as any, async (req, res) => {
+  // OAuth protected-resource metadata (served whenever OAuth is enabled so MCP
+  // clients can discover the authorization server). Public by design — it
+  // contains no secrets, only discovery pointers.
+  app.get("/.well-known/oauth-protected-resource", (req, res) => {
+    const cfg = getMcpOAuthConfig();
+    if (!cfg.enabled) {
+      res.status(404).json({ error: "not_found", message: "OAuth is not enabled for this MCP server" });
+      return;
+    }
+    const fallbackResource = `${req.protocol}://${req.get("host")}${basePath}`;
+    res.json(protectedResourceMetadata(cfg, fallbackResource));
+  });
+
+  // Resolve the static-token check once so mcpAuth can fall back to it.
+  const guard = mcpAuth(checkAuthToken as any);
+
+  app.post(basePath, guard, async (req, res) => {
     try {
       const sessionId = req.headers["mcp-session-id"] as string | undefined;
       let transport: StreamableHTTPServerTransport;
@@ -78,8 +99,8 @@ export function setupMcpServer(app: express.Application, basePath = "/mcp"): voi
     await transport.handleRequest(req, res);
   };
 
-  app.get(basePath, checkAuthToken as any, handleSessionRequest);
-  app.delete(basePath, checkAuthToken as any, handleSessionRequest);
+  app.get(basePath, guard, handleSessionRequest);
+  app.delete(basePath, guard, handleSessionRequest);
 
   console.log(`MCP server initialized with Streamable HTTP transport at ${basePath}`);
 }

--- a/tests/auth/mcpOAuth.test.ts
+++ b/tests/auth/mcpOAuth.test.ts
@@ -1,0 +1,148 @@
+/**
+ * OAuth resource-server behavior for the MCP endpoint. Uses a real local JWKS
+ * server + jose-signed tokens so JWT verification is exercised end-to-end (not
+ * mocked). Auth is asserted via GET /mcp: passing the guard yields a 400
+ * "missing mcp-session-id" (transport-level), so 400 == authenticated and
+ * 401 == rejected — cleanly isolating auth from the MCP transport.
+ */
+import express from 'express';
+import request from 'supertest';
+import http from 'http';
+import { generateKeyPair, exportJWK, SignJWT, type KeyLike } from 'jose';
+import { setupMcpServer } from '../../src/modules/mcpServer';
+import { __resetJwksForTests } from '../../src/auth/mcpOAuth';
+import { getOrGenerateApiToken } from '../../src/common/apiToken';
+
+const ISSUER = 'https://as.test.local';
+const AUDIENCE = 'https://mcp.test.local/mcp';
+
+describe('MCP OAuth resource server', () => {
+  let jwksServer: http.Server;
+  let jwksUrl: string;
+  let privateKey: KeyLike;
+  let apiToken: string;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeAll(async () => {
+    apiToken = getOrGenerateApiToken();
+    const { publicKey, privateKey: pk } = await generateKeyPair('RS256');
+    privateKey = pk as KeyLike;
+    const jwk = await exportJWK(publicKey);
+    jwk.kid = 'test-key-1';
+    jwk.alg = 'RS256';
+    jwk.use = 'sig';
+
+    jwksServer = http.createServer((_req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ keys: [jwk] }));
+    });
+    await new Promise<void>((resolve) => jwksServer.listen(0, resolve));
+    const addr = jwksServer.address();
+    if (!addr || typeof addr === 'string') throw new Error('no jwks port');
+    jwksUrl = `http://127.0.0.1:${addr.port}/jwks`;
+
+    for (const k of ['MCP_OAUTH_ENABLED', 'MCP_OAUTH_ISSUER', 'MCP_OAUTH_JWKS_URI', 'MCP_OAUTH_AUDIENCE', 'MCP_OAUTH_RESOURCE', 'MCP_OAUTH_ALLOW_STATIC_FALLBACK']) {
+      savedEnv[k] = process.env[k];
+    }
+  });
+
+  afterAll(async () => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k]; else process.env[k] = v;
+    }
+    await new Promise<void>((resolve) => jwksServer.close(() => resolve()));
+  });
+
+  beforeEach(() => {
+    __resetJwksForTests();
+    process.env.MCP_OAUTH_ISSUER = ISSUER;
+    process.env.MCP_OAUTH_JWKS_URI = jwksUrl;
+    process.env.MCP_OAUTH_AUDIENCE = AUDIENCE;
+    process.env.MCP_OAUTH_RESOURCE = AUDIENCE;
+    delete process.env.MCP_OAUTH_ALLOW_STATIC_FALLBACK;
+  });
+
+  function makeApp() {
+    const app = express();
+    app.use(express.json());
+    setupMcpServer(app);
+    return app;
+  }
+
+  async function signToken(overrides: { exp?: string; aud?: string; iss?: string } = {}) {
+    return await new SignJWT({})
+      .setProtectedHeader({ alg: 'RS256', kid: 'test-key-1' })
+      .setIssuer(overrides.iss ?? ISSUER)
+      .setAudience(overrides.aud ?? AUDIENCE)
+      .setIssuedAt()
+      .setExpirationTime(overrides.exp ?? '5m')
+      .sign(privateKey);
+  }
+
+  describe('with OAuth enabled', () => {
+    beforeEach(() => { process.env.MCP_OAUTH_ENABLED = 'true'; });
+
+    it('serves protected-resource metadata', async () => {
+      const res = await request(makeApp()).get('/.well-known/oauth-protected-resource');
+      expect(res.status).toBe(200);
+      expect(res.body.resource).toBe(AUDIENCE);
+      expect(res.body.authorization_servers).toEqual([ISSUER]);
+      expect(res.body.jwks_uri).toBe(jwksUrl);
+      expect(res.body.bearer_methods_supported).toContain('header');
+    });
+
+    it('rejects a request with no token and points at the metadata', async () => {
+      const res = await request(makeApp()).get('/mcp');
+      expect(res.status).toBe(401);
+      expect(res.headers['www-authenticate']).toContain('resource_metadata=');
+      expect(res.headers['www-authenticate']).toContain('/.well-known/oauth-protected-resource');
+    });
+
+    it('accepts a valid JWT (passes the guard -> 400 missing session)', async () => {
+      const token = await signToken();
+      const res = await request(makeApp()).get('/mcp').set('Authorization', `Bearer ${token}`);
+      expect(res.status).toBe(400);
+      expect(res.text).toContain('mcp-session-id');
+    });
+
+    it('rejects an expired JWT with a 401 challenge', async () => {
+      const token = await signToken({ exp: '-1m' });
+      const res = await request(makeApp()).get('/mcp').set('Authorization', `Bearer ${token}`);
+      expect(res.status).toBe(401);
+      expect(res.headers['www-authenticate']).toContain('error="invalid_token"');
+    });
+
+    it('rejects a JWT with the wrong audience', async () => {
+      const token = await signToken({ aud: 'https://someone-else/mcp' });
+      const res = await request(makeApp()).get('/mcp').set('Authorization', `Bearer ${token}`);
+      expect(res.status).toBe(401);
+    });
+
+    it('still accepts the static API token by default (fallback)', async () => {
+      const res = await request(makeApp()).get('/mcp').set('Authorization', `Bearer ${apiToken}`);
+      expect(res.status).toBe(400); // passed auth, failed at transport
+    });
+
+    it('rejects the static API token when fallback is disabled', async () => {
+      process.env.MCP_OAUTH_ALLOW_STATIC_FALLBACK = 'false';
+      const res = await request(makeApp()).get('/mcp').set('Authorization', `Bearer ${apiToken}`);
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('with OAuth disabled (default)', () => {
+    beforeEach(() => { delete process.env.MCP_OAUTH_ENABLED; });
+
+    it('does not serve protected-resource metadata', async () => {
+      const res = await request(makeApp()).get('/.well-known/oauth-protected-resource');
+      expect(res.status).toBe(404);
+    });
+
+    it('still enforces the static API token', async () => {
+      const noTok = await request(makeApp()).get('/mcp');
+      expect(noTok.status).toBe(401);
+      const withTok = await request(makeApp()).get('/mcp').set('Authorization', `Bearer ${apiToken}`);
+      expect(withTok.status).toBe(400); // passed static auth
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds the **resource-server** half of the MCP authorization model (MCP spec 2025-06-18 / OAuth 2.1 + RFC 9728) to the `/mcp` Streamable HTTP endpoint. **Off by default** — when disabled, `/mcp` keeps using the static bearer token with zero behavior change.

When `MCP_OAUTH_ENABLED=true`:
- Serves RFC 9728 Protected Resource Metadata at `GET /.well-known/oauth-protected-resource` (discovery: issuer + `jwks_uri`).
- Validates incoming bearer JWTs against the authorization server's JWKS (signature, `iss`, `aud`, `exp`) via `jose`; audience-bound (RFC 8707).
- Emits a `WWW-Authenticate` challenge pointing at the metadata so MCP clients discover the AS and complete the flow.
- Keeps a static API-token fallback (toggle via `MCP_OAUTH_ALLOW_STATIC_FALLBACK`) for local/CLI use.

## Notable
- Pins `jose@^5` as a direct dep: the SDK's transitive `jose@6` is ESM-only and won't load under the CommonJS ts-jest setup; v5 is dual CJS/ESM and the SDK keeps its own nested copy.
- New module `src/auth/mcpOAuth.ts`; `setupMcpServer` shares one guard across POST/GET/DELETE.

## Tests
`tests/auth/mcpOAuth.test.ts` drives a **real local JWKS server + jose-signed tokens**: valid / expired / wrong-audience JWTs, no-token challenge, static fallback on/off, and disabled-mode. Full suite **1659/1659**, type-check clean.

## Out of scope
Embedded authorization server (local `/authorize` + `/token` + dynamic client registration) — tracked as a future roadmap item. See `docs/MCP_OAUTH.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)